### PR TITLE
59 renaming project

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,10 +14,10 @@ sys.path.insert(0, os.path.abspath("../src/"))
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "adler"
+project = "lsst-adler"
 copyright = "2023, Adler Team"
 author = "Adler Team"
-release = version("adler")
+release = version("lsst-adler")
 # for example take major/minor
 version = ".".join(release.split(".")[:2])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "adler"
+name = "lsst-adler"
 license = {file = "LICENSE"}
 readme = "README.md"
 authors = [
@@ -24,7 +24,7 @@ dependencies = [
 ]
 
 [project.urls]
-"Source Code" = "https://github.com/lsst-uk/adler"
+"Source Code" = "https://github.com/lsst-uk/lsst-adler"
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #59.
- Changes the name of the project in pyproject.toml to "lsst-adler" to avoid conflict with an existing PyPi package.
- Once installed, the actual modules are still accessed in the same way, i.e. from `adler.dataclasses.AdlerPlanetoid import AdlerPlanetoid` still works, and the adler call on the command line works in the same way. The only thing that is different is the package name. 
- I tested this in a fresh Conda environment with a fresh pip install and it's happy enough but I would VERY MUCH like someone else to double-check.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does adler run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
