### PR TITLE
136 Validating and testing new argument

### DIFF
--- a/src/adler/utilities/AdlerCLIArguments.py
+++ b/src/adler/utilities/AdlerCLIArguments.py
@@ -37,6 +37,9 @@ class AdlerCLIArguments:
         if self.ssObjectId_list:
             self._validate_ssObjectId_list()
 
+        if self.sql_filename:
+            self._validate_sql_filename()
+
     def _validate_filter_list(self):
         expected_filters = ["u", "g", "r", "i", "z", "y"]
 
@@ -92,4 +95,13 @@ class AdlerCLIArguments:
             )
             raise ValueError(
                 "The file supplied for the command-line argument --ssObjectId_list cannot be found."
+            )
+
+    def _validate_sql_filename(self):
+        self.sql_filename = os.path.abspath(self.sql_filename)
+
+        if not os.path.exists(self.sql_filename):
+            logging.error("The file supplied for the command-line argument --sql_filename cannot be found.")
+            raise ValueError(
+                "The file supplied for the command-line argument --sql_filename cannot be found."
             )

--- a/tests/adler/utilities/test_AdlerCLIArguments.py
+++ b/tests/adler/utilities/test_AdlerCLIArguments.py
@@ -129,9 +129,9 @@ def test_AdlerCLIArguments_badlist():
         "./fake_input/here.txt",
         ["g", "r", "i"],
         [60000.0, 67300.0],
-        "./definitely_fake_folder/",
+        "./",
         "output",
-        None,
+        "./",
     )
 
     with pytest.raises(ValueError) as bad_list_error:
@@ -139,5 +139,25 @@ def test_AdlerCLIArguments_badlist():
 
     assert (
         bad_list_error.value.args[0]
-        == "The output path for the command-line argument --outpath cannot be found."
+        == "The file supplied for the command-line argument --ssObjectId_list cannot be found."
+    )
+
+
+def test_AdlerCLIArguments_badsql():
+    bad_sql_arguments = args(
+        "666",
+        None,
+        ["g", "r", "i"],
+        [60000.0, 67300.0],
+        "./",
+        "output",
+        "./dummy_database.db",
+    )
+
+    with pytest.raises(ValueError) as bad_sql_error:
+        bad_sql_object = AdlerCLIArguments(bad_sql_arguments)
+
+    assert (
+        bad_sql_error.value.args[0]
+        == "The file supplied for the command-line argument --sql_filename cannot be found."
     )


### PR DESCRIPTION
Fixes #136 .
- Added validation for the `--sql_filename` command-line argument that makes sure the filename exists.
- Fixed a unit test that did not do what I thought it did.
- Wrote a unit test to cover this.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does adler run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
