### PR TITLE
PhaseCurve bounds

### DIFF
--- a/src/adler/science/PhaseCurve.py
+++ b/src/adler/science/PhaseCurve.py
@@ -61,7 +61,7 @@ class PhaseCurve:
         self,
         H=18,
         phase_parameter_1=0.2,
-        phase_parameter_2=None,
+        phase_parameter_2=0.2,
         model_name="HG",
         H_err=None,
         phase_parameter_1_err=None,
@@ -78,7 +78,7 @@ class PhaseCurve:
         if model_name == "HG":
             self.model_function = HG(H=H, G=self.phase_parameter_1)
         elif model_name == "HG1G2":
-            self.model_function = HG1G2(H=H, G1=self.phase_parameter_1, G2=self.phase_parameter_1)
+            self.model_function = HG1G2(H=H, G1=self.phase_parameter_1, G2=self.phase_parameter_2)
         elif model_name == "HG12":
             self.model_function = HG12(H=H, G12=self.phase_parameter_1)
         elif model_name == "HG12_Pen16":
@@ -160,6 +160,8 @@ class PhaseCurve:
 
         # clean the input dictionary
         del_keys = []
+        if "model_function" in model_dict.keys():
+            del_keys.append("model_function")
         for key, value in model_dict.items():
             if not hasattr(self, key):
                 del_keys.append(key)
@@ -242,6 +244,30 @@ class PhaseCurve:
         """
 
         return self.model_function(phase_angle)
+
+    def ReducedMagBounds(self, phase_angle, std=1):
+        """Accounting for the parameter uncertainties, return the minimum and maximum reduced magnitudes of the phasecurve model for a given phase angle(s)
+
+        phase_angle - value or array, must have astropy units of degrees
+
+        Parameters
+        -----------
+        phase_angle : float or array
+           value or array of phase angles at which to evaluate the phasecurve model.
+           Must have astropy units of degrees if sbpy model uses units, otherwise pass radian values.
+        std : float
+           Number of standard deviations we want to consider when determining the minimum/maximum parameter values, where we assume that the parameter uncertainty is representative of a 1 sigma std in a gaussian distribution.
+        Returns
+        ----------
+
+        return_value : float or array
+           The phasecurve model reduced magnitude at the given phase angle(s)
+
+        """
+
+        self.model_function(phase_angle)
+
+        return np.amin(red_mag), np.amax(red_mag)
 
     def ModelResiduals(self, phase_angle, reduced_mag):
         """For a set of phase curve observations, return the residuals to the PhaseCurve model.

--- a/src/adler/science/PhaseCurve.py
+++ b/src/adler/science/PhaseCurve.py
@@ -2,6 +2,7 @@ from sbpy.photometry import HG, HG1G2, HG12, HG12_Pen16, LinearPhaseFunc
 import astropy.units as u
 import numpy as np
 from astropy.modeling.fitting import LevMarLSQFitter
+import itertools
 
 # translation between sbpy and adler field names
 SBPY_ADLER_DICT = {
@@ -246,9 +247,7 @@ class PhaseCurve:
         return self.model_function(phase_angle)
 
     def ReducedMagBounds(self, phase_angle, std=1):
-        """Accounting for the parameter uncertainties, return the minimum and maximum reduced magnitudes of the phasecurve model for a given phase angle(s)
-
-        phase_angle - value or array, must have astropy units of degrees
+        """Accounting for the parameter uncertainties, return the minimum and maximum reduced magnitudes of the phasecurve model for a given phase angle(s). This is done by determining the minimum and maximum values of each parameter given the uncertainty (and some std, assuming a gaussian distribution). A PhaseCurve model is made for all unique combinations of the min, max of each parameter. For each PhaseCurve model the ReducedMag is calculated; the overall min/max ReducedMag is determined at each phase angle.
 
         Parameters
         -----------
@@ -260,14 +259,55 @@ class PhaseCurve:
         Returns
         ----------
 
-        return_value : float or array
-           The phasecurve model reduced magnitude at the given phase angle(s)
+        pc_bounds : dict
+           mag_min - The minimum reduced magnitude of all PhaseCurve models at every phase angle
+           mag_max - The maximum reduced magnitude of all PhaseCurve models at every phase angle
+           mag_mean - The mean reduced magnitude of all PhaseCurve models at every phase angle
+           PhaseCurves - A list of all unique PhaseCurve models given the possible combinations of parameters and their uncertainties
 
         """
 
-        self.model_function(phase_angle)
+        # Get all parameters in the model that have an uncertainty
+        err_keys = [x for x in self.__dict__.keys() if "_err" in x and getattr(self, x) is not None]
 
-        return np.amin(red_mag), np.amax(red_mag)
+        # calculate the min, max for each parameter with uncertainty
+        params = {}
+        for x_err in err_keys:
+            x = x_err.replace("_err", "")
+            _x = getattr(self, x)
+            _x_err = getattr(self, x_err)
+            plus = _x + (std * _x_err)
+            minus = _x - (std * _x_err)
+            params[x] = [plus, minus]
+
+        # Get all possible combinations of the min, max for each parameter
+        p_vals = [params[x] for x in params.keys()]
+        all_p_vals = list(itertools.product(*p_vals))
+
+        # make a new PhaseCurve model for each set of parameters
+        # Determine the reduced magnitudes for the given phase angle range
+        mags = []
+        pcs = []
+        for p in all_p_vals:
+            _dict = self.__dict__.copy()
+            for i, x in enumerate(params.keys()):
+                _dict[x] = p[i]
+            _pc = PhaseCurve().InitModelDict(_dict)
+            pcs.append(_pc)
+            _mag = _pc.ReducedMag(phase_angle)
+            mags.append(_mag)
+        mags = np.array(mags)
+
+        # Calculate the magnitude statistics
+        # Get the absolute maximum and minimum value at each phase angle for all possible models
+        mag_min = np.amin(mags, axis=0)
+        mag_max = np.amax(mags, axis=0)
+        mag_mean = np.mean(mags, axis=0)
+
+        # Store results in a dictionary
+        pc_bounds = {"mag_min": mag_min, "mag_max": mag_max, "mag_mean": mag_mean, "PhaseCurves": pcs}
+
+        return pc_bounds
 
     def ModelResiduals(self, phase_angle, reduced_mag):
         """For a set of phase curve observations, return the residuals to the PhaseCurve model.

--- a/tests/adler/science/test_PhaseCurve.py
+++ b/tests/adler/science/test_PhaseCurve.py
@@ -144,6 +144,7 @@ def test_PhaseCurve_FitModel_HG_bounds():
     assert pc2.phase_parameter_1 == 0.1
     assert pc2.phase_parameter_1_err is not None
 
+
 def test_PhaseCurve_ReducedMagBounds():
     """Test calculating the reduced magnitude from a PhaseCurve object."""
 
@@ -189,6 +190,7 @@ def test_PhaseCurve_ReducedMagBounds():
     assert len(pc_bounds["PhaseCurves"]) == 4
     assert_array_less(pc_bounds["mag_min"], red_mag)
     assert_array_less(red_mag, pc_bounds["mag_max"])
+
 
 def test_PhaseCurve_FitModel_resample():
 

--- a/tests/adler/science/test_PhaseCurve.py
+++ b/tests/adler/science/test_PhaseCurve.py
@@ -73,7 +73,6 @@ def test_PhaseCurve_FitModel_HG():
     # the new fitted model should have the same parameters as the input model
     assert pc2.H == pc1.H
     assert pc2.phase_parameter_1 == pc1.phase_parameter_1
-    assert pc2.phase_parameter_2 is None
     assert pc1.phase_parameter_1_err is None  # the first model had no uncertainties
     assert pc2.phase_parameter_1_err is not None  # the fitted model has some uncertainties
 
@@ -95,7 +94,6 @@ def test_PhaseCurve_FitModel_HG_no_units():
     # the new fitted model should have the same parameters as the input model
     assert pc2.H == pc1.H
     assert pc2.phase_parameter_1 == pc1.phase_parameter_1
-    assert pc2.phase_parameter_2 is None
     assert pc1.phase_parameter_1_err is None  # the first model had no uncertainties
     assert pc2.phase_parameter_1_err is not None  # the fitted model has some uncertainties
 

--- a/tests/adler/science/test_PhaseCurve.py
+++ b/tests/adler/science/test_PhaseCurve.py
@@ -1,5 +1,5 @@
 from adler.science.PhaseCurve import PhaseCurve
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_array_less, assert_almost_equal
 import pytest
 import numpy as np
 import astropy.units as u
@@ -141,6 +141,53 @@ def test_PhaseCurve_FitModel_HG_bounds():
     assert pc_fit.G.bounds == (0.0, 0.1)
     assert pc2.phase_parameter_1 == 0.1
     assert pc2.phase_parameter_1_err is not None
+
+
+def test_PhaseCurve_ReducedMagBounds():
+    """Test calculating the reduced magnitude from a PhaseCurve object."""
+
+    # define the phase angles
+    alpha = np.radians(np.array([0, 10]))
+
+    # Test the HG12 model
+    pc = PhaseCurve(model_name="HG12", H_err=0.1, phase_parameter_1_err=0.1)
+
+    # find the reduced mag and the bounds
+    red_mag = pc.ReducedMag(alpha)
+    pc_bounds = pc.ReducedMagBounds(alpha)
+
+    assert_almost_equal(pc_bounds["mag_min"][0], pc.H - pc.H_err)
+    assert_almost_equal(pc_bounds["mag_max"][0], pc.H + pc.H_err)
+    assert_almost_equal(pc_bounds["mag_mean"][0], pc.H)
+    assert len(pc_bounds["PhaseCurves"]) == 4
+    assert_array_less(pc_bounds["mag_min"], red_mag)
+    assert_array_less(red_mag, pc_bounds["mag_max"])
+
+    # also test the HG1G2 model with all uncertainties
+    pc = PhaseCurve(model_name="HG1G2", H_err=0.1, phase_parameter_1_err=0.1, phase_parameter_2_err=0.1)
+    # find the reduced mag and the bounds
+    red_mag = pc.ReducedMag(alpha)
+    pc_bounds = pc.ReducedMagBounds(alpha)
+
+    assert_almost_equal(pc_bounds["mag_min"][0], pc.H - pc.H_err)
+    assert_almost_equal(pc_bounds["mag_max"][0], pc.H + pc.H_err)
+    assert_almost_equal(pc_bounds["mag_mean"][0], pc.H)
+    assert len(pc_bounds["PhaseCurves"]) == 8
+    assert_array_less(pc_bounds["mag_min"], red_mag)
+    assert_array_less(red_mag, pc_bounds["mag_max"])
+
+    # also test the HG1G2 model with only 2/3 uncertainties
+    pc = PhaseCurve(model_name="HG1G2", H_err=0.1, phase_parameter_1_err=0.1)
+    # find the reduced mag and the bounds
+    red_mag = pc.ReducedMag(alpha)
+    pc_bounds = pc.ReducedMagBounds(alpha)
+
+    assert_almost_equal(pc_bounds["mag_min"][0], pc.H - pc.H_err)
+    assert_almost_equal(pc_bounds["mag_max"][0], pc.H + pc.H_err)
+    assert_almost_equal(pc_bounds["mag_mean"][0], pc.H)
+    assert len(pc_bounds["PhaseCurves"]) == 4
+    assert_array_less(pc_bounds["mag_min"], red_mag)
+    assert_array_less(red_mag, pc_bounds["mag_max"])
 
 
 # TODO: test absmag


### PR DESCRIPTION
Fixes #191

Adding a function that can calculate the absolute minimum and maximum values of reduced magnitude given the uncertainties on the PhaseCurve parameters.

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [x] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does adler run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
