### PR TITLE
python3.10 -> 3.12

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/pre-commit-ci.yml
+++ b/.github/workflows/pre-commit-ci.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.10'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: ['macos-latest','ubuntu-latest']
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.12']
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ testpaths = [
 
 [tool.black]
 line-length = 110
-target-version = ["py38"]
+target-version = ["py312"]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ testpaths = [
 
 [tool.black]
 line-length = 110
-target-version = ["py312"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
Follow on of #235. I noticed that making a fresh install of an adler conda env and pre-commit ended up looking for python3.10 and breaking. Turns out there were other instances of python<3.12 hiding in the workflows. I have now removed this and things seem to be working.

N.B. to test this, nuking the pre-commit cache and reinstalling seems to do the trick, e.g.:
```
rm -rf /home/jrobinson/.cache/pre-commit
pre-commit install
```

## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [x] Do all the units tests run successfully?
- [x] Does adler run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
