### PR TITLE
Observations within time

### DIFF
--- a/notebooks/adler_examples.ipynb
+++ b/notebooks/adler_examples.ipynb
@@ -72,6 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# retreive the Observations object for the r filter\n",
     "obs_r = planetoid.observations_in_filter(\"r\")"
    ]
   },
@@ -82,7 +83,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Inspect the Observations as a dict\n",
     "obs_r.__dict__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54a54b37-8b41-42bb-9b14-905acfbe7610",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can also retrieve observations in all filters as a dataframe\n",
+    "df_obs = planetoid.observations_within_time()\n",
+    "df_obs"
    ]
   },
   {
@@ -324,9 +338,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "adler-dev-3.12",
    "language": "python",
-   "name": "python3"
+   "name": "adler-dev-3.12"
   },
   "language_info": {
    "codemirror_mode": {
@@ -338,7 +352,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/src/adler/objectdata/AdlerPlanetoid.py
+++ b/src/adler/objectdata/AdlerPlanetoid.py
@@ -984,7 +984,7 @@ class AdlerPlanetoid:
 
         Returns
         -------
-        observations : list of Observations
+        observations : pandas.DataFrame
 
         """
 

--- a/src/adler/objectdata/AdlerPlanetoid.py
+++ b/src/adler/objectdata/AdlerPlanetoid.py
@@ -972,6 +972,30 @@ class AdlerPlanetoid:
 
         return self.observations_by_filter[filter_index]
 
+    def observations_within_time(self, start, stop):
+        """Get observations taken within a given time interval.
+
+
+        Parameters
+        ----------
+        start, stop : float
+            The time limits as modified Julian dates.
+
+
+        Returns
+        -------
+        observations : list of Observations
+
+        """
+
+        result = pd.DataFrame()
+        for obs in self.observations_by_filter:
+            df = pd.DataFrame(obs.__dict__)
+            result = pd.concat([result, df]).reset_index(drop=True)
+
+        i = (obs.midPointMjdTai >= start) * (obs.midPointMjdTai <= stop)
+        return result.iloc[i]
+
     def SSObject_in_filter(self, filter_name):
         """User-friendly helper function. Returns the filter-dependent values from SSObject for a given filter.
 

--- a/src/adler/objectdata/AdlerPlanetoid.py
+++ b/src/adler/objectdata/AdlerPlanetoid.py
@@ -990,11 +990,13 @@ class AdlerPlanetoid:
 
         result = pd.DataFrame()
         for obs in self.observations_by_filter:
-            df = pd.DataFrame(obs.__dict__)
+            df = pd.DataFrame(obs.__dict__ | {"filter_name": [obs.filter_name] * obs.num_obs})
             result = pd.concat([result, df]).reset_index(drop=True)
 
-        i = (obs.midPointMjdTai >= start) * (obs.midPointMjdTai <= stop)
-        return result.iloc[i]
+        i = (result.midPointMjdTai >= start) * (result.midPointMjdTai <= stop)
+        result = result.iloc[i]
+        result.sort_values("midPointMjdTai")
+        return result
 
     def SSObject_in_filter(self, filter_name):
         """User-friendly helper function. Returns the filter-dependent values from SSObject for a given filter.

--- a/src/adler/objectdata/AdlerPlanetoid.py
+++ b/src/adler/objectdata/AdlerPlanetoid.py
@@ -972,14 +972,14 @@ class AdlerPlanetoid:
 
         return self.observations_by_filter[filter_index]
 
-    def observations_within_time(self, start, stop):
-        """Get observations taken within a given time interval.
+    def observations_within_time(self, start=None, stop=None):
+        """Get a dataframe of all observations (across all filters) taken within a given time interval.
 
 
         Parameters
         ----------
         start, stop : float
-            The time limits as modified Julian dates.
+            The time limits as modified Julian dates. Optional, if not declared then get all data
 
 
         Returns
@@ -993,9 +993,13 @@ class AdlerPlanetoid:
             df = pd.DataFrame(obs.__dict__ | {"filter_name": [obs.filter_name] * obs.num_obs})
             result = pd.concat([result, df]).reset_index(drop=True)
 
+        if start is None:
+            start = np.amin(result["midPointMjdTai"])
+        if stop is None:
+            stop = np.amax(result["midPointMjdTai"])
         i = (result.midPointMjdTai >= start) * (result.midPointMjdTai <= stop)
-        result = result.iloc[i]
-        result.sort_values("midPointMjdTai")
+        result = result[i]
+        result = result.sort_values("midPointMjdTai")
         return result
 
     def SSObject_in_filter(self, filter_name):

--- a/tests/adler/objectdata/test_AdlerPlanetoid.py
+++ b/tests/adler/objectdata/test_AdlerPlanetoid.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from numpy.testing import assert_almost_equal
+from numpy.testing import assert_almost_equal, assert_array_equal
 
 from adler.utilities.tests_utilities import get_test_data_filepath
 from adler.objectdata.AdlerPlanetoid import AdlerPlanetoid
@@ -110,6 +110,25 @@ def test_observations_in_filter():
         test_planetoid.observations_in_filter("f")
 
     assert error_info_1.value.args[0] == "Filter f is not in AdlerPlanetoid.filter_list."
+
+
+def test_observations_within_time():
+    test_planetoid = AdlerPlanetoid.construct_from_SQL(ssoid, test_db_path)
+
+    df_obs = test_planetoid.observations_within_time()
+
+    assert len(df_obs) == test_planetoid.SSObject.numObs
+    assert_array_equal(np.sort(np.unique(df_obs["filter_name"])), np.sort(test_planetoid.filter_list))
+
+    # test retrieving between a start and stop date
+    t1 = 61000
+    t2 = 63500
+    df_obs2 = test_planetoid.observations_within_time(start=t1, stop=t2)
+    assert len(df_obs2) == len(df_obs[(df_obs["midPointMjdTai"] >= t1) & (df_obs["midPointMjdTai"] <= t2)])
+
+    # test setting only the start (stop is set to max date automatically)
+    df_obs3 = test_planetoid.observations_within_time(start=t1)
+    assert len(df_obs3) == len(df_obs[(df_obs["midPointMjdTai"] >= t1)])
 
 
 def test_SSObject_in_filter():


### PR DESCRIPTION
I was interested in a way to get all observations within a time interval, over all filters.  This PR adds a function to AdlerPlanetoid named observations_within_time to do so.  It combines all the data into a sorted data frame.  If there is a better way to do this within Adler or a more Adler way to do it, feedback is welcome.


## Review Checklist for Source Code Changes

- [x] Does pip install still work?
- [ ] Have you written a unit test for any new functions?
- [ ] Do all the units tests run successfully?
- [ ] Does adler run successfully on a test set of input files/databases?
- [x] Have you used black on the files you have updated to confirm python programming style guide enforcement?
